### PR TITLE
Reorganize the docs, and link from the README to the docs (and vice versa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 [![Continuous Integration](https://github.com/chriselrod/ThreadingUtilities.jl/workflows/CI/badge.svg)](https://github.com/chriselrod/ThreadingUtilities.jl/actions?query=workflow%3ACI)
 [![Continuous Integration (Julia nightly)](https://github.com/chriselrod/ThreadingUtilities.jl/workflows/CI%20(Julia%20nightly)/badge.svg)](https://github.com/chriselrod/ThreadingUtilities.jl/actions?query=workflow%3A%22CI+%28Julia+nightly%29%22)
 [![Coverage](https://codecov.io/gh/chriselrod/ThreadingUtilities.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/chriselrod/ThreadingUtilities.jl)
+
+Utilities for low overhead threading in Julia.
+
+Please see the [documentation](https://chriselrod.github.io/ThreadingUtilities.jl/stable).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,8 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Public API" => "public-api.md",
+        "Internal (Private)" => "internals.md",
     ],
     strict=true,
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,15 @@
+```@meta
+CurrentModule = ThreadingUtilities
+```
+
+# Public API
+
+```@index
+Pages   = ["api.md"]
+```
+
+```@autodocs
+Modules = [ThreadingUtilities]
+Public = true
+Private = false
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,9 +4,8 @@ CurrentModule = ThreadingUtilities
 
 # ThreadingUtilities
 
-```@index
-```
+[ThreadingUtilities](https://github.com/chriselrod/ThreadingUtilities.jl)
+provides utilities for low overhead threading in Julia.
 
-```@autodocs
-Modules = [ThreadingUtilities]
-```
+The source code for this package is available in the
+[GitHub repository](https://github.com/chriselrod/ThreadingUtilities.jl).

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,0 +1,15 @@
+```@meta
+CurrentModule = ThreadingUtilities
+```
+
+# Internals (Private)
+
+```@index
+Pages   = ["internal.md"]
+```
+
+```@autodocs
+Modules = [ThreadingUtilities]
+Private = true
+Public = false
+```


### PR DESCRIPTION
The links from GitHub (README) to docs and docs to GitHub are really convenient to have.