### PR TITLE
Run the Aqua tests in a separate workflow

### DIFF
--- a/.ci/aqua/Project.toml
+++ b/.ci/aqua/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"

--- a/.ci/aqua/aqua.jl
+++ b/.ci/aqua/aqua.jl
@@ -1,0 +1,6 @@
+using ThreadingUtilities
+
+using Aqua
+using Test
+
+Aqua.test_all(ThreadingUtilities)

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -1,0 +1,44 @@
+name: Run Aqua.jl on ThreadingUtilities.jl
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'LICENSE.md'
+      - 'README.md'
+      - '.github/workflows/TagBot.yml'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'LICENSE.md'
+      - 'README.md'
+      - '.github/workflows/TagBot.yml'
+jobs:
+  aqua:
+    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+        threads:
+          - '5'
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - run: |
+          julia --project=.ci/aqua -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()
+            Pkg.precompile()'
+      - run: julia --project=.ci/aqua .ci/aqua/aqua.jl

--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,12 @@ version = "0.1.1"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-Aqua = "0.5"
 VectorizationBase = "0.15"
 julia = "1.5"
 
 [extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [targets]
-test = ["Aqua", "Test", "VectorizationBase"]
+test = ["Test", "VectorizationBase"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using ThreadingUtilities
-using VectorizationBase, Aqua
+using VectorizationBase
 using Test
 
 @testset "THREADPOOL" begin
@@ -58,8 +58,6 @@ end
 end
 
 @testset "ThreadingUtilities.jl" begin
-    @time Aqua.test_all(ThreadingUtilities)
-
     if length(ThreadingUtilities.TASKS) > 0
         x = rand(100);
         w = rand(100);
@@ -72,5 +70,4 @@ end
         @test y == x
         @test z == w
     end
-
 end


### PR DESCRIPTION
Based on my comments in https://github.com/chriselrod/ThreadingUtilities.jl/issues/3 (specifically https://github.com/chriselrod/ThreadingUtilities.jl/issues/3#issuecomment-762670118, https://github.com/chriselrod/ThreadingUtilities.jl/issues/3#issuecomment-762670839, and https://github.com/chriselrod/ThreadingUtilities.jl/issues/3#issuecomment-762671041), I'm starting to become suspicious that the Aqua tests are actually responsible for the timeouts.

So this pull request moves the Aqua tests to a separate workflow.