### PR TITLE
Print a warning if the kernel is allowed to move threads about

### DIFF
--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -22,22 +22,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.5'
-          - '1'
-          - 'nightly'
+        arch:
+          - x64
+          - x86
+        exclusive:
+          - 'false'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         threads:
           - '5'
-        arch:
-          - x64
-          - x86
+        version:
+          - '1.5'
+          - '1'
+          - 'nightly'
         exclude:
           - os: macOS-latest
             arch: x86 # 32-bit Julia binaries are not available on macOS
+        include:
+          - exclusive: 'true'
+            threads: '2'
+            arch: x64
+            os: ubuntu-latest
+            version: '1'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -57,6 +65,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
+          JULIA_EXCLUSIVE: ${{ matrix.exclusive }}
           JULIA_NUM_THREADS: ${{ matrix.threads }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,22 +22,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.5'
-          - '1'
-          - '^1.6.0-0' # TODO: remove this line once Julia 1.6.0 is released
+        arch:
+          - x64
+          - x86
+        exclusive:
+          - 'false'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         threads:
           - '5'
-        arch:
-          - x64
-          - x86
+        version:
+          - '1.5'
+          - '1'
+          - 'nightly'
         exclude:
           - os: macOS-latest
             arch: x86 # 32-bit Julia binaries are not available on macOS
+        include:
+          - exclusive: 'true'
+            threads: '2'
+            arch: x64
+            os: ubuntu-latest
+            version: '1'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -57,6 +65,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
+          JULIA_EXCLUSIVE: ${{ matrix.exclusive }}
           JULIA_NUM_THREADS: ${{ matrix.threads }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreadingUtilities"
 uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
@@ -13,8 +13,9 @@ julia = "1.5"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [targets]
-test = ["Aqua", "Test", "VectorizationBase"]
+test = ["Aqua", "InteractiveUtils", "Test", "VectorizationBase"]

--- a/src/ThreadingUtilities.jl
+++ b/src/ThreadingUtilities.jl
@@ -18,8 +18,10 @@ const THREADPOOLPTR =  Ref{Ptr{UInt}}(C_NULL);
 include("atomics.jl")
 include("threadtasks.jl")
 include("utils.jl")
+include("warnings.jl")
 
 function __init__()
+    _print_exclusivity_warning()
     nt = min(Threads.nthreads(),(Sys.CPU_THREADS)::Int) - 1
     resize!(THREADPOOL, THREADBUFFERSIZE * nt + (something(L₁CACHE.linesize,64) ÷ sizeof(UInt)) - 1)
     THREADPOOL .= 0

--- a/src/warnings.jl
+++ b/src/warnings.jl
@@ -1,0 +1,50 @@
+function _string_to_bool(s::AbstractString)
+    b = tryparse(Bool, s)
+    if b isa Nothing
+        return false
+    else
+        return b::Bool
+    end
+end
+
+function _is_suppress_warning()
+    s = get(ENV, "SUPPRESS_THREADINGUTILITIES_WARNING", "")
+    b = _string_to_bool(s)::Bool
+    return b
+end
+
+function _is_julia_exclusive()
+    s = strip(get(ENV, "JULIA_EXCLUSIVE", "0"))
+    # From https://github.com/JuliaLang/julia/blob/efc986003356be5daea6ccd9e38008de961c18aa/doc/src/manual/environment-variables.md:
+    # If set to anything besides 0, then Julia's thread policy is consistent
+    # with running on a dedicated machine: the master thread is on proc 0, and
+    # threads are affinitized. Otherwise, Julia lets the operating system handle
+    # thread policy.
+    i = tryparse(Int, s)
+    if isempty(s)
+        return false
+    elseif s == "0" || i == 0
+        return false
+    else
+        return true
+    end
+end
+
+function _print_exclusivity_warning()
+    is_julia_exclusive = _is_julia_exclusive()::Bool
+    if !is_julia_exclusive
+        suppress_warning = _is_suppress_warning()::Bool
+        if !suppress_warning
+            msg = string(
+                "The JULIA_EXCLUSIVE environment variable is not set to 1. ",
+                "Therefore, the kernel is allowed to move threads to different ",
+                "cores. We recommend that you set the JULIA_EXCLUSIVE ",
+                "environment variable to 1. To suppress this warning, set the ",
+                "SUPPRESS_THREADINGUTILITIES_WARNING environment ",
+                "variable to 1.",
+            )
+            @debug(msg)
+        end
+    end
+    return nothing
+end

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,0 +1,3 @@
+@testset "Aqua.jl" begin
+    @time Aqua.test_all(ThreadingUtilities)
+end

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -1,0 +1,3 @@
+@testset "Internals" begin
+    @test ThreadingUtilities.store!(pointer(UInt[]), (), 1) == 1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,99 +1,15 @@
 using ThreadingUtilities
-using VectorizationBase, Aqua
 using Test
+using VectorizationBase
 
-@testset "THREADPOOL" begin
-    @test isconst(ThreadingUtilities, :THREADPOOL) # test that ThreadingUtilities.THREADPOOL is a constant
-    @test ThreadingUtilities.THREADPOOL isa Vector{UInt}
-    @test eltype(ThreadingUtilities.THREADPOOL) === UInt
-    @test length(ThreadingUtilities.THREADPOOL) == ThreadingUtilities.THREADBUFFERSIZE * (min(Threads.nthreads(),(Sys.CPU_THREADS)::Int) - 1) + (something(VectorizationBase.L₁CACHE.linesize,64) ÷ sizeof(UInt)) - 1
-end
+import Aqua
+import InteractiveUtils
 
-struct Copy{P} end
-function (::Copy{P})(p::Ptr{UInt}) where {P}
-    _, (ptry,ptrx,N) = ThreadingUtilities.load(p, P, 1)
-    @simd ivdep for n ∈ 1:N
-        vstore!(ptry, vload(ptrx, (n,)), (n,))
-    end
-end
-@generated function copy_ptr(::A, ::B) where {A,B}
-    c = Copy{Tuple{A,B,Int}}()
-    quote
-        @cfunction($c, Cvoid, (Ptr{UInt},))
-    end
-end
-function setup_copy!(p, y, x)
-    N = length(y)
-    @assert length(x) == N
-    py = stridedpointer(y)
-    px = stridedpointer(x)
-    fptr = copy_ptr(py, px)
-    offset = ThreadingUtilities.store!(p, fptr, 0)
-    ThreadingUtilities.store!(p, (py,px,N), offset)
-end
+include("test-suite-preamble.jl")
 
-@inline function launch_thread_copy!(tid, y, x)
-    p = ThreadingUtilities.taskpointer(tid)
-    while true
-        if ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.SPIN, ThreadingUtilities.STUP)
-            setup_copy!(p, y, x)
-            @assert ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.STUP, ThreadingUtilities.TASK)
-            return
-        elseif ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.WAIT, ThreadingUtilities.STUP)
-            setup_copy!(p, y, x)
-            @assert ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.STUP, ThreadingUtilities.LOCK)
-            ThreadingUtilities.wake_thread!(tid % UInt)
-            return
-        end
-        ThreadingUtilities.pause()
-    end
-end
+include("internals.jl")
+include("threadingutilities.jl")
+include("threadpool.jl")
+include("warnings.jl")
 
-function test_copy(tid)
-    a = rand(100_000);
-    b = rand(100_000);
-    c = rand(100_000);
-    x = similar(a) .= NaN;
-    y = similar(b) .= NaN;
-    z = similar(c) .= NaN;
-    launch_thread_copy!(tid, x, a)
-    yield()
-    # sleep(1e-3)
-    ThreadingUtilities.__wait(tid)
-    launch_thread_copy!(tid, y, b)
-    yield()
-    # sleep(1e-3)
-    ThreadingUtilities.__wait(tid)
-    launch_thread_copy!(tid, z, c)
-    yield()
-    # sleep(1e-3)
-    ThreadingUtilities.__wait(tid)
-    @test a == x
-    @test b == y
-    @test c == z
-end
-
-@testset "Internals" begin
-    @test ThreadingUtilities.store!(pointer(UInt[]), (), 1) == 1
-end
-
-@time Aqua.test_all(ThreadingUtilities)
-
-@testset "ThreadingUtilities.jl" begin
-    @test all(i -> isone(unsafe_load(ThreadingUtilities.taskpointer(i))), eachindex(ThreadingUtilities.TASKS))
-    @test all(eachindex(ThreadingUtilities.TASKS)) do tid
-        ThreadingUtilities.load(ThreadingUtilities.taskpointer(tid), ThreadingUtilities.ThreadState) === ThreadingUtilities.WAIT
-    end
-    @test all(eachindex(ThreadingUtilities.TASKS)) do tid
-        ThreadingUtilities._atomic_load(ThreadingUtilities.taskpointer(tid)) === reinterpret(UInt, ThreadingUtilities.WAIT)
-    end
-    foreach(test_copy, eachindex(ThreadingUtilities.TASKS))
-
-    x = rand(UInt, 3);
-    GC.@preserve x begin
-        ThreadingUtilities._atomic_store!(pointer(x), zero(UInt))
-        @test ThreadingUtilities._atomic_xchg!(pointer(x), ThreadingUtilities.WAIT) == ThreadingUtilities.SPIN
-        @test ThreadingUtilities._atomic_umax!(pointer(x), ThreadingUtilities.STUP) == ThreadingUtilities.WAIT
-        @test ThreadingUtilities.load(pointer(x), ThreadingUtilities.ThreadState) == ThreadingUtilities.STUP
-    end
-end
+include("aqua.jl") # run the Aqua.jl tests last

--- a/test/test-suite-preamble.jl
+++ b/test/test-suite-preamble.jl
@@ -1,0 +1,13 @@
+using InteractiveUtils: versioninfo
+
+versioninfo()
+
+@info("Running tests with $(Threads.nthreads()) threads")
+
+function is_coverage()
+    return !iszero(Base.JLOptions().code_coverage)
+end
+
+const coverage = is_coverage()
+
+@info("Code coverage is $(coverage ? "enabled" : "disabled")")

--- a/test/threadingutilities.jl
+++ b/test/threadingutilities.jl
@@ -1,0 +1,82 @@
+struct Copy{P} end
+function (::Copy{P})(p::Ptr{UInt}) where {P}
+    _, (ptry,ptrx,N) = ThreadingUtilities.load(p, P, 1)
+    @simd ivdep for n ∈ 1:N
+        vstore!(ptry, vload(ptrx, (n,)), (n,))
+    end
+end
+@generated function copy_ptr(::A, ::B) where {A,B}
+    c = Copy{Tuple{A,B,Int}}()
+    quote
+        @cfunction($c, Cvoid, (Ptr{UInt},))
+    end
+end
+function setup_copy!(p, y, x)
+    N = length(y)
+    @assert length(x) == N
+    py = stridedpointer(y)
+    px = stridedpointer(x)
+    fptr = copy_ptr(py, px)
+    offset = ThreadingUtilities.store!(p, fptr, 0)
+    ThreadingUtilities.store!(p, (py,px,N), offset)
+end
+
+@inline function launch_thread_copy!(tid, y, x)
+    p = ThreadingUtilities.taskpointer(tid)
+    while true
+        if ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.SPIN, ThreadingUtilities.STUP)
+            setup_copy!(p, y, x)
+            @assert ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.STUP, ThreadingUtilities.TASK)
+            return
+        elseif ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.WAIT, ThreadingUtilities.STUP)
+            setup_copy!(p, y, x)
+            @assert ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.STUP, ThreadingUtilities.LOCK)
+            ThreadingUtilities.wake_thread!(tid % UInt)
+            return
+        end
+        ThreadingUtilities.pause()
+    end
+end
+
+function test_copy(tid)
+    a = rand(100_000);
+    b = rand(100_000);
+    c = rand(100_000);
+    x = similar(a) .= NaN;
+    y = similar(b) .= NaN;
+    z = similar(c) .= NaN;
+    launch_thread_copy!(tid, x, a)
+    yield()
+    # sleep(1e-3)
+    ThreadingUtilities.__wait(tid)
+    launch_thread_copy!(tid, y, b)
+    yield()
+    # sleep(1e-3)
+    ThreadingUtilities.__wait(tid)
+    launch_thread_copy!(tid, z, c)
+    yield()
+    # sleep(1e-3)
+    ThreadingUtilities.__wait(tid)
+    @test a == x
+    @test b == y
+    @test c == z
+end
+
+@testset "ThreadingUtilities.jl" begin
+    @test all(i -> isone(unsafe_load(ThreadingUtilities.taskpointer(i))), eachindex(ThreadingUtilities.TASKS))
+    @test all(eachindex(ThreadingUtilities.TASKS)) do tid
+        ThreadingUtilities.load(ThreadingUtilities.taskpointer(tid), ThreadingUtilities.ThreadState) === ThreadingUtilities.WAIT
+    end
+    @test all(eachindex(ThreadingUtilities.TASKS)) do tid
+        ThreadingUtilities._atomic_load(ThreadingUtilities.taskpointer(tid)) === reinterpret(UInt, ThreadingUtilities.WAIT)
+    end
+    foreach(test_copy, eachindex(ThreadingUtilities.TASKS))
+
+    x = rand(UInt, 3);
+    GC.@preserve x begin
+        ThreadingUtilities._atomic_store!(pointer(x), zero(UInt))
+        @test ThreadingUtilities._atomic_xchg!(pointer(x), ThreadingUtilities.WAIT) == ThreadingUtilities.SPIN
+        @test ThreadingUtilities._atomic_umax!(pointer(x), ThreadingUtilities.STUP) == ThreadingUtilities.WAIT
+        @test ThreadingUtilities.load(pointer(x), ThreadingUtilities.ThreadState) == ThreadingUtilities.STUP
+    end
+end

--- a/test/threadpool.jl
+++ b/test/threadpool.jl
@@ -1,0 +1,6 @@
+@testset "THREADPOOL" begin
+    @test isconst(ThreadingUtilities, :THREADPOOL) # test that ThreadingUtilities.THREADPOOL is a constant
+    @test ThreadingUtilities.THREADPOOL isa Vector{UInt}
+    @test eltype(ThreadingUtilities.THREADPOOL) === UInt
+    @test length(ThreadingUtilities.THREADPOOL) == ThreadingUtilities.THREADBUFFERSIZE * (min(Threads.nthreads(),(Sys.CPU_THREADS)::Int) - 1) + (something(VectorizationBase.L₁CACHE.linesize,64) ÷ sizeof(UInt)) - 1
+end

--- a/test/warnings.jl
+++ b/test/warnings.jl
@@ -1,0 +1,24 @@
+@testset "warnings" begin
+    @testset "exclusivity warning" begin
+        withenv("JULIA_DEBUG" => "all", "SUPPRESS_THREADINGUTILITIES_WARNING" => "0", "JULIA_EXCLUSIVE" => "") do
+            @test (@test_logs (:debug, "The JULIA_EXCLUSIVE environment variable is not set to 1. Therefore, the kernel is allowed to move threads to different cores. We recommend that you set the JULIA_EXCLUSIVE environment variable to 1. To suppress this warning, set the SUPPRESS_THREADINGUTILITIES_WARNING environment variable to 1.") match_mode=:any ThreadingUtilities._print_exclusivity_warning()) isa Nothing
+        end
+        withenv("SUPPRESS_THREADINGUTILITIES_WARNING" => "1", "JULIA_EXCLUSIVE" => "") do
+            @test ThreadingUtilities._print_exclusivity_warning() isa Nothing
+        end
+        withenv("JULIA_DEBUG" => "all", "SUPPRESS_THREADINGUTILITIES_WARNING" => "0", "JULIA_EXCLUSIVE" => "0") do
+            @test (@test_logs (:debug, "The JULIA_EXCLUSIVE environment variable is not set to 1. Therefore, the kernel is allowed to move threads to different cores. We recommend that you set the JULIA_EXCLUSIVE environment variable to 1. To suppress this warning, set the SUPPRESS_THREADINGUTILITIES_WARNING environment variable to 1.") match_mode=:any ThreadingUtilities._print_exclusivity_warning()) isa Nothing
+        end
+        withenv("SUPPRESS_THREADINGUTILITIES_WARNING" => "1", "JULIA_EXCLUSIVE" => "0") do
+            @test ThreadingUtilities._print_exclusivity_warning() isa Nothing
+        end
+    end
+
+    @testset "utility functions" begin
+        @test ThreadingUtilities._string_to_bool("true")
+        @test ThreadingUtilities._string_to_bool("1")
+        @test !ThreadingUtilities._string_to_bool("false")
+        @test !ThreadingUtilities._string_to_bool("0")
+        @test !ThreadingUtilities._string_to_bool("")
+    end
+end


### PR DESCRIPTION
This PR will print a warning if the kernel is allowed to move threads about.

This is based on my reading of https://github.com/JuliaLang/julia/blob/master/doc/src/manual/environment-variables.md#julia_exclusive and https://github.com/JuliaLang/julia/blob/master/src/threading.c (in particular, starting at line 415: https://github.com/JuliaLang/julia/blob/efc986003356be5daea6ccd9e38008de961c18aa/src/threading.c#L415). If I understand correctly, Julia will allow the kernel to move threads around if and only if the `JULIA_EXCLUSIVE` environment variable is `0`.