### PR TITLE
increasing THREADBUFFERSIZE

### DIFF
--- a/src/ThreadingUtilities.jl
+++ b/src/ThreadingUtilities.jl
@@ -22,7 +22,7 @@ end
 end
 const TASKS = Task[]
 const LINESPACING = 256 # maximum cache-line size among contemporary CPUs.
-const THREADBUFFERSIZE = 512
+const THREADBUFFERSIZE = 1024
 const THREADPOOL = UInt[]
 const THREADPOOLPTR =  Ref{Ptr{UInt}}(C_NULL);
 


### PR DESCRIPTION
Hey, 

Following a [comment on discourse](https://discourse.julialang.org/t/a-macro-to-unroll-by-hand-but-not-by-hand/74633/16) from @chriselrod, I increased the buffer size on my local machine.

I do not necessarily want you to merge this, but I'd like to understand what are the implications of such a change ? If nothing harmful, then maybe we could increase it once and for all in the registered version.