### PR TITLE
Fix worktree counting on Julia 1.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreadingUtilities"
 uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 ManualMemory = "d125e4d3-2237-4719-b19c-fa641b8a4667"

--- a/src/threadtasks.jl
+++ b/src/threadtasks.jl
@@ -61,7 +61,11 @@ end
 @noinline function wake_thread!(_tid::T) where {T<:Integer}
   tid = _tid % Int
   tidp1 = tid + one(tid)
-  assume(unsigned(length(Base.Workqueues)) > unsigned(tid))
+  @static if VERSION >= v"1.13-"
+    assume(unsigned(length(Base.Workqueues())) > unsigned(tid))
+  else
+    assume(unsigned(length(Base.Workqueues)) > unsigned(tid))
+  end
   assume(unsigned(length(TASKS)) > unsigned(tidp1))
   @inbounds push!(Base.Workqueues[tidp1], TASKS[tid])
   ccall(:jl_wakeup_thread, Cvoid, (Int16,), tid % Int16)


### PR DESCRIPTION
Rather trivial. Fixes #63.

Can confirm that all tests, and Polyester.jl tests, now pass on 1.13-rc1.